### PR TITLE
Loop timer + minor

### DIFF
--- a/engine/count.go
+++ b/engine/count.go
@@ -52,11 +52,10 @@ func (p *CountProcessor) Handle(events []event.Event) {
 	p.samplesMu.Lock()
 	defer p.samplesMu.Unlock()
 
-	col := p.col
 	for _, e := range events {
-		if isMatch(e, col.Event, col.Labels) {
-			labelVals := make([]string, len(col.Labels))
-			for i, label := range col.Labels {
+		if isMatch(e, p.col.Event, p.col.Labels) {
+			labelVals := make([]string, len(p.col.Labels))
+			for i, label := range p.col.Labels {
 				labelVals[i] = e.Labels[label]
 			}
 			key := mapKeyForSample(p.col.Labels, labelVals)

--- a/engine/histogram.go
+++ b/engine/histogram.go
@@ -53,18 +53,17 @@ func (p *HistogramProcessor) Handle(events []event.Event) {
 	p.samplesMu.Lock()
 	defer p.samplesMu.Unlock()
 
-	col := p.col
 	for _, e := range events {
-		if isMatch(e, col.Event, col.Labels) {
-			labelVals := make([]string, len(col.Labels))
-			for i, label := range col.Labels {
+		if isMatch(e, p.col.Event, p.col.Labels) {
+			labelVals := make([]string, len(p.col.Labels))
+			for i, label := range p.col.Labels {
 				labelVals[i] = e.Labels[label]
 			}
-			key := mapKeyForSample(col.Labels, labelVals)
+			key := mapKeyForSample(p.col.Labels, labelVals)
 			_, ok := p.samples[key]
 			if !ok {
 				p.samples[key] = histogramSample{
-					histogram:   histogram.NewHistogram(col.Buckets),
+					histogram:   histogram.NewHistogram(p.col.Buckets),
 					labelValues: labelVals,
 				}
 			}

--- a/engine/histogram/histogram.go
+++ b/engine/histogram/histogram.go
@@ -37,7 +37,7 @@ func (h *Histogram) Add(v float64) {
 }
 
 func (h *Histogram) Buckets() map[float64]uint64 {
-	m := make(map[float64]uint64)
+	m := make(map[float64]uint64, len(h.buckets))
 	var le uint64
 	for i, b := range h.buckets {
 		le += h.counts[i]


### PR DESCRIPTION
Hello,

Thanks for your project 🙏. A few minor changes if you agree with them:

* Changing the loop logic to check if we reach the `BufferFlushWindow` limit. With the current implementation, we do the check only when we receive a new event. So if we don't receive new events for some time (for whatever reasons), we won't flush the buffer. The change is about using `time.Timer`.
* Regarding the `Handle` method, I may be missing something but I didn't get the point to copy `p.col` as it wasn't mutated anywhere 🤔 At least the two implementations weren't strictly consistent:
  * `histogram.go` was using `col` when calling `mapKeyForSample` [link](https://github.com/rakyll/events-to-prom/blob/main/engine/histogram.go#L63)
  * Whereas `count.go` was using `p.col` when calling `mapKeyForSample` [link](https://github.com/rakyll/events-to-prom/blob/main/engine/count.go#L62)
* Minor change in `engine.go` to enforce read-only channels
* Adding the map size when initializing the buckets map [histogram.go](https://github.com/rakyll/events-to-prom/blob/main/engine/histogram/histogram.go#L40)